### PR TITLE
fix for Mojolicious 5.54

### DIFF
--- a/lib/Mojolicious/Plugin/YamlConfig.pm
+++ b/lib/Mojolicious/Plugin/YamlConfig.pm
@@ -30,6 +30,7 @@ sub parse {
 
     # Render
     $content = $self->render($content, $file, $conf, $app);
+    $content = Encode::encode('UTF-8', $content);
 
     my @broken = qw(YAML YAML::Old YAML::Tiny);
     if (grep { $class eq $_ } @broken) {


### PR DESCRIPTION
Hello,

This recent change https://github.com/kraih/mojo/commit/27a351852423d197ea1e8d42adcc7fc3eb81fa77 is causing tests to fail for Mojolicious::Plugin::YamlConfig with perl 5.20.1 and Mojolicious 5.54.

The attached change fixes it.

best,
Brian
